### PR TITLE
Upgraded hashring to 3.2.0

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -39,7 +39,11 @@ function Client(opts) {
         autodiscover: false,
         disabled: false,
         hosts: null,
-        reconnect: true
+        reconnect: true,
+        onNetError: function onNetError(err) { console.error(err); },
+        queue: true,
+        netTimeout: 500,
+        backoffLimit: 10000
     });
 
     // Iterate over options, assign each to this object
@@ -47,6 +51,7 @@ function Client(opts) {
         this[key] = value;
     }, this);
 
+    debug('Connect options', opts);
     this.connect();
 }
 
@@ -103,7 +108,8 @@ Client.prototype.getHostList = function() {
             onConnect: function() {
                 // Do the autodiscovery, then resolve with hosts
                 return deferred.resolve(this.autodiscovery());
-            }
+            },
+            onError: this.onNetError
         });
 
         return deferred.promise;
@@ -132,7 +138,8 @@ Client.prototype.connectToHosts = function() {
             reconnect: this.reconnect,
             onConnect: function() {
                 client.flushBuffer();
-            }
+            },
+            onError: this.onNetError
         });
     }, this);
 
@@ -311,16 +318,23 @@ Client.prototype.run = function(command, args, cb) {
             // Run this command
             connection[command].apply(connection, args).then(deferred.resolve).catch(deferred.reject);
         } else {
-            this.buffer = this.buffer || new Queue();
 
-            this.buffer.push({
-                cmd: command,
-                args: args,
-                key: args[0],
-                deferred: deferred
-            });
+            if(this.queue) {
+
+                this.buffer = this.buffer || new Queue();
+
+                this.buffer.push({
+                    cmd: command,
+                    args: args,
+                    key: args[0],
+                    deferred: deferred
+                });
+
+            } else {
+                return Promise.resolve(null).nodeify(cb);
+            }
         }
-
+        
         return deferred.promise.nodeify(cb);
     }
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -11,7 +11,9 @@ var _ = require('lodash'),
     net = require('net'),
     Promise = require('bluebird'),
     Queue = require('collections/deque'),
-    util = require('util');
+    util = require('util'),
+    EventEmitter = require('events').EventEmitter;
+
 
 /**
  * Connection constructor
@@ -37,13 +39,23 @@ function Connection(opts) {
     if (opts.onConnect) {
         this.onConnect = opts.onConnect;
     }
+
+    if (opts.onError) {
+        this.onError = opts.onError;
+    } else {
+        this.onError = function onError(err) { this.emit('error'); console.error(err); };
+    }
+    this.netTimeout = opts.netTimeout || 500;
+    this.backoffLimit = opts.backoffLimit || 10000;
     this.reconnect = opts.reconnect;
     this.disconnecting = false;
     this.ready = false;
     this.backoff = opts.backoff || 10;
-
+    
     this.connect();
 }
+
+util.inherits(Connection, EventEmitter);
 
 /**
  * Disconnect connection
@@ -62,11 +74,11 @@ Connection.prototype.disconnect = function() {
 Connection.prototype.connect = function() {
     var self = this;
     var params = {
-        port: this.port
+        port: self.port
     };
 
-    if (this.host) {
-        params.host = this.host;
+    if (self.host) {
+        params.host = self.host;
     }
 
     debug('connecting to host %s:%s', params.host, params.port);
@@ -77,45 +89,50 @@ Connection.prototype.connect = function() {
 
     } else {
         // Initialize a new client, connect
-        this.client = net.connect(params);
-        this.client.setNoDelay(true);
-
+        self.client = net.connect(params);
+        self.client.setTimeout(self.netTimeout);
+        self.client.on('error', self.onError);
+        self.client.setNoDelay(true);
+        
         // If reconnect is enabled, we want to re-initiate connection if it is ended
-        if (this.reconnect) {
-            this.client.on('close', function() {
-                this.ready = false;
+        if (self.reconnect) {
+            self.client.on('close', function() {
+                self.emit('close');
+                self.ready = false;
                 // Wait before retrying and double each time. Backoff starts at 10ms and will
                 // plateau at 1 minute.
-                if (this.backoff < 60000) {
-                    this.backoff *= 2;
+                if (self.backoff < self.backoffLimit) {
+                    self.backoff *= 2;
                 }
-                debug('connection to memcache lost, reconnecting in %sms...', this.backoff);
+                debug('connection to memcache lost, reconnecting in %sms...', self.backoff);
                 setTimeout(function() {
                     // Only want to do this if a disconnect was not triggered intentionally
                     if (!self.disconnecting) {
-                        debug('attempting to reconnect to memcache now.', this.backoff);
+                        debug('attempting to reconnect to memcache now.', self.backoff);
                         self.client.destroy();
+                        self.client = null;
                         self.connect();
                     }
-                }, this.backoff);
+                }, self.backoff);
             });
         }
     }
 
-    this.client.on('connect', function() {
+    self.client.on('connect', function() {
+        self.emit('connect');
         debug('successfully (re)connected!');
-        this.ready = true;
+        self.ready = true;
         // Reset backoff if we connect successfully
-        this.backoff = 10;
+        self.backoff = 10;
 
         // If an onConnect handler was specified, execute it
-        if (this.onConnect) {
-            this.onConnect();
+        if (self.onConnect) {
+            self.onConnect();
         }
-        this.flushQueue();
-    }.bind(this));
+        self.flushQueue();
+    });
 
-    carrier.carry(this.client, this.read.bind(this));
+    carrier.carry(self.client, self.read.bind(self));
 };
 
 Connection.prototype.read = function(data) {
@@ -339,7 +356,7 @@ Connection.prototype.get = function(key, opts) {
                             return d.toString();
                         })
                         .catch(function(err) {
-                            if (err.toString() === 'OperationalError: incorrect header check') {
+                            if (err.toString().indexOf('Error: incorrect header check') > -1) {
                                 // Basically we get this OperationalError when we try to decompress a value
                                 // which was not previously compressed. We return null instead of bubbling
                                 // this error up the chain because we want to represent it as a cache miss

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chai": "^1.9.1",
     "collections": "^1.2.1",
     "debug": "^1.0.0",
-    "hashring": "^3.0.0",
+    "hashring": "^3.2.0",
     "lodash": "^2.4.1",
     "ramda": "^0.2.3"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memcache-plus",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Better memcache for node",
   "main": "index.js",
   "scripts": {

--- a/test/connection.js
+++ b/test/connection.js
@@ -23,15 +23,15 @@ describe('Connection', function() {
     });
 
     it('does connect', function(done) {
-        connection.client.on('connect', function() {
+        connection.on('connect', function() {
             done();
         });
     });
 
     it('reconnects, if enabled and connection lost', function(done) {
-        connection.client.on('connect', function() {
+        connection.on('connect', function() {
             connection.client.end();
-            connection.client.on('connect', function() {
+            connection.on('connect', function() {
                 done();
             });
         });
@@ -40,9 +40,9 @@ describe('Connection', function() {
     describe('does not reconnect when', function() {
         it('reconnect is disabled and connection lost', function(done) {
             connection = new Connection({ reconnect: false });
-            connection.client.on('connect', function() {
+            connection.on('connect', function() {
                 connection.client.end();
-                connection.client.on('connect', function() {
+                connection.on('connect', function() {
                     done(new Error('The client should not have attempted to reconnect'));
                 });
                 setTimeout(function() {
@@ -53,9 +53,9 @@ describe('Connection', function() {
 
         it('intentionally disconnected', function(done) {
             connection = new Connection();
-            connection.client.on('connect', function() {
+            connection.on('connect', function() {
                 connection.disconnect();
-                connection.client.on('connect', function() {
+                connection.on('connect', function() {
                     done(new Error('The client should not have attempted to reconnect'));
                 });
                 setTimeout(function() {


### PR DESCRIPTION
The old version of hashring does not build against node 4.2.6. Upgrade to hashring 3.2.0 seems to work.

Tests pass realting to hashring. Another issue with zlib currently breaks tests which I will look at next.