### PR TITLE
Added missing call to EventEmitter.call on constructor

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -23,6 +23,9 @@ var _ = require('lodash'),
  * @param {object} opts - The options for this Connection instance
  */
 function Connection(opts) {
+
+    EventEmitter.call(this);
+
     opts = opts || {};
 
     _.defaults(opts, {
@@ -51,7 +54,7 @@ function Connection(opts) {
     this.disconnecting = false;
     this.ready = false;
     this.backoff = opts.backoff || 10;
-    
+
     this.connect();
 }
 
@@ -93,7 +96,7 @@ Connection.prototype.connect = function() {
         self.client.setTimeout(self.netTimeout);
         self.client.on('error', self.onError);
         self.client.setNoDelay(true);
-        
+
         // If reconnect is enabled, we want to re-initiate connection if it is ended
         if (self.reconnect) {
             self.client.on('close', function() {


### PR DESCRIPTION
Sorry @victorquinn  to bother you again. Checking this, I found out that when I made the connection an event emitter, I forgot to call EventEmitter.call on the constructor. It must be called.

> "The EventEmitter constructor initializes various properties now. It still works fine as an OOP inheritance parent, but you have to do inheritance properly. The Broken-Style JS inheritance pattern will not work when extending the EventEmitter class. This inheritance style was never supported, but prior to 0.10, it did not actually break."

from https://github.com/nodejs/node/wiki/API-changes-between-v0.8-and-v0.10