### PR TITLE
Clear response queue on connection failure

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -70,6 +70,21 @@ Connection.prototype.disconnect = function() {
 };
 
 /**
+ * Destroy connection immediately
+ */
+Connection.prototype.destroy = function() {
+    var self = this;
+
+    this.client.destroy();
+    this.client = null;
+
+    this.queue.forEach(function(deferred) {
+        deferred.reject(new Error('Memcache connection lost'));
+    });
+    this.queue.clear();
+};
+
+/**
  * Initialize connection
  *
  * @api private
@@ -112,8 +127,7 @@ Connection.prototype.connect = function() {
                     // Only want to do this if a disconnect was not triggered intentionally
                     if (!self.disconnecting) {
                         debug('attempting to reconnect to memcache now.', self.backoff);
-                        self.client.destroy();
-                        self.client = null;
+                        self.destroy();
                         self.connect();
                     }
                 }, self.backoff);


### PR DESCRIPTION
This is a serious bug.

If a connection dies and is retried then request/response pairs can get mixed up, and a request for one key may receive a response for another.