### PR TITLE
Simplify client run logic

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -161,7 +161,8 @@ Client.prototype.flushBuffer = function() {
             // First, retrieve the correct connection out of the hashring
             var connection = this.connections[this.ring.get(item.key)];
 
-            connection[item.cmd].apply(connection, item.args).then(item.deferred.resolve);
+            var promise = connection[item.cmd].apply(connection, item.args);
+            promise.then(item.deferred.resolve, item.deferred.reject);
         }
     }
 };
@@ -289,7 +290,7 @@ Client.prototype.getMulti = function(keys, opts, cb) {
         cb = opts;
         opts = {};
     }
-    
+
     return Promise.props(R.reduce(function(acc, key) {
         acc[key] = self.run('get', [key, opts], null);
         return acc;
@@ -305,38 +306,34 @@ Client.prototype.getMulti = function(keys, opts, cb) {
  * @returns {Promise}
  */
 Client.prototype.run = function(command, args, cb) {
-    var deferred = misc.defer(args[0]);
-
     if (this.disabled) {
         return Promise.resolve(null).nodeify(cb);
-    } else {
+    }
 
-        if (this.ready()) {
-            // First, retrieve the correct connection out of the hashring
-            var connection = this.connections[this.ring.get(args[0])];
+    if (this.ready()) {
+        // First, retrieve the correct connection out of the hashring
+        var connection = this.connections[this.ring.get(args[0])];
 
-            // Run this command
-            connection[command].apply(connection, args).then(deferred.resolve).catch(deferred.reject);
-        } else {
+        // Run this command
+        return connection[command].apply(connection, args);
+    }
 
-            if(this.queue) {
+    if (this.queue) {
+        var deferred = misc.defer(args[0]);
 
-                this.buffer = this.buffer || new Queue();
+        this.buffer = this.buffer || new Queue();
 
-                this.buffer.push({
-                    cmd: command,
-                    args: args,
-                    key: args[0],
-                    deferred: deferred
-                });
+        this.buffer.push({
+            cmd: command,
+            args: args,
+            key: args[0],
+            deferred: deferred,
+        });
 
-            } else {
-                return Promise.resolve(null).nodeify(cb);
-            }
-        }
-        
         return deferred.promise.nodeify(cb);
     }
+
+    return Promise.resolve(null).nodeify(cb);
 };
 
 module.exports = Client;


### PR DESCRIPTION
Minor patches to `client.js` that simplify branching.

Doesn't use deferred when not needed, and fixes a bug where rejections are dropped.